### PR TITLE
refactor: Collection の get で重複しているメッセージを探す

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,11 @@ const fetchAll = async function (channel: TextChannel) {
     messages.push(...ret.values());
     if (ret.size < 100) break;
   }
-  return new Collection(messages.sort((a, b) => BigInt(a.id) < BigInt(b.id) ? 1 : -1).map(e => [e.id, e]));
+  return new Collection(
+    messages
+      .sort((a, b) => (BigInt(a.id) < BigInt(b.id) ? 1 : -1))
+      .map((e) => [e.content, e])
+  );
 }
 
 const client = new Client({ intents: Intents.FLAGS.GUILDS | Intents.FLAGS.GUILD_MESSAGES });
@@ -46,7 +50,8 @@ client.on('messageCreate', async msg => {
   if( !(msg.channel instanceof TextChannel) ) return;
   if (msg.channelId != process.env.CHANNEL_ID ) return;
   const messages = await fetchAll(msg.channel)
-  if(messages.find(m => m.content == msg.content && m.id != msg.id)) {
+  const message = messages.get(msg.content);
+  if (message && message.id !== msg.id) {
     msg.reply("被ってるよ")
   }
 });


### PR DESCRIPTION
Collection の find は愚直に探していくので size が増えると遅くなると思われる。
https://github.com/discordjs/collection/blob/main/src/index.ts#L216-L222

Collection(中身は Map)の get は O(1) のようなので、 content を Collection の key にして本文から直接メッセージのオブジェクトを引くようにして高速化した。

副作用として、同じ content のメッセージが ID が新しい方で上書きされるので、過去の重複が分からなくなってしまう。

